### PR TITLE
Add auto-scroll behavior to `MessageBox` on focus

### DIFF
--- a/src/Components/MessageBox.tsx
+++ b/src/Components/MessageBox.tsx
@@ -3,6 +3,7 @@ import {SendHorizontal, MessageCircle} from 'lucide-react'
 import {FormEvent, useEffect, useState} from "react";
 import {AnimatePresence, motion} from "motion/react";
 import axios from 'axios';
+import {FocusEvent} from "react";
 
 interface Message {
     _id?: string;
@@ -32,7 +33,14 @@ function MessageBox(){
             return null;
         }
     };
-    
+
+    const handleFocus = (event: FocusEvent<HTMLTextAreaElement>) => {
+        //possibly add an isExpanded and/or isMobile check
+        setTimeout(()=> {
+            event.target.scrollIntoView({behavior: "smooth", block: "end",});
+        }, 300)
+    }
+
     function getMessagesById(id: string) {
         axios({
             method: 'GET',
@@ -187,6 +195,7 @@ function MessageBox(){
                                 onChange={(e) => setInputMessage(e.target.value)}
                                 className="rounded-md m-3 w-full px-2 py-1 resize-none text-black"
                                 disabled={isLoading}
+                                onFocus={handleFocus}
                             />
                             <button type="submit" className="mr-3" disabled={isLoading}>
                                 <SendHorizontal className="m-auto" />


### PR DESCRIPTION
- Implemented an auto-scroll feature in `MessageBox` by adding a `handleFocus` function.
- This ensures the input smoothly scrolls into view when focused, enhancing user experience.

---

Closes #17