### PR TITLE
Prevent ExpandableDiv from collapsing on link clicks

### DIFF
--- a/src/Components/ExpandableDiv.tsx
+++ b/src/Components/ExpandableDiv.tsx
@@ -58,6 +58,10 @@ function ExpandableDiv({
 
     function handleMouseUp(e: React.MouseEvent) {
         // Only toggle if mouse down and mouse up occurred on the same element
+        const target = e.target as HTMLElement;
+        if (target.closest('a')) { //check if the click target is a link, if it is, don't collapse the div
+            return;
+        }
         if (divRef.current && mouseDownTarget === e.target) {
             const target = e.target as Node;
 


### PR DESCRIPTION
- Fixed an issue in `ExpandableDiv` where it would collapse when clicking on links inside it.  
- Added a check to ensure collapse only occurs when appropriate.  
- Improves user interaction by maintaining expected behavior.  

---

Closes #57