### PR TITLE
Add zoom/pan and back button support to ExpandableImage modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-i18next": "^16.0.0",
-        "react-textarea-autosize": "^8.5.7"
+        "react-textarea-autosize": "^8.5.7",
+        "react-zoom-pan-pinch": "^3.7.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.19.0",
@@ -4920,6 +4921,20 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.7.0.tgz",
+      "integrity": "sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-i18next": "^16.0.0",
-    "react-textarea-autosize": "^8.5.7"
+    "react-textarea-autosize": "^8.5.7",
+    "react-zoom-pan-pinch": "^3.7.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",

--- a/src/Components/ExpandableImage.tsx
+++ b/src/Components/ExpandableImage.tsx
@@ -1,6 +1,7 @@
 ﻿import {AnimatePresence, motion} from "motion/react";
 import {useEffect, useState} from "react";
 import {createPortal} from "react-dom";
+import {TransformComponent, TransformWrapper} from "react-zoom-pan-pinch";
 
 type ExpandableImageProps = {
     src:string,
@@ -28,7 +29,13 @@ export const ExpandableImage = ({src, alt, }:ExpandableImageProps) => {
             }
         }
 
+        const handlePopState = () => {
+            setIsOpened(false);
+        }
+
         document.addEventListener("keydown", handleKeyDown);
+        document.addEventListener("popstate", handlePopState);
+
 
         return () => {
             document.body.style.overflow = "unset";
@@ -61,8 +68,14 @@ export const ExpandableImage = ({src, alt, }:ExpandableImageProps) => {
                                     exit={{ opacity: 0 }}
                                     className="fixed inset-0 bg-black/50 backdrop-blur-md flex items-center justify-center z-50" onClick={() => setIsOpened(false)}
                                 >
-                                    <motion.img layoutId={src} transition={{duration:0.5}} onClick={(e) => e.stopPropagation()}
-                                                className="max-h-[90vh] max-w-[90vw] rounded-2xl object-contain" src={src}/>
+                                    <motion.div layout onClick={(e) => e.stopPropagation()}>
+                                        <TransformWrapper>
+                                            <TransformComponent wrapperClass="!w-auto !h-auto">
+                                                <motion.img layoutId={src} transition={{duration:0.5}}
+                                                            className="max-h-[90vh] max-w-[90vw] rounded-2xl object-contain" src={src}/>
+                                            </TransformComponent>
+                                        </TransformWrapper>
+                                    </motion.div>
                                 </motion.div>
                             }
                         </AnimatePresence>,


### PR DESCRIPTION
### Description

This pull request introduces the following features:
- **Zoom and Pan Functionality:** Integrated `react-zoom-pan-pinch` for image manipulation within the `ExpandableImage` modal. Added `TransformWrapper` and `TransformComponent` for interactive zoom and pan support. Improved the overlay structure for better user interaction.
- **Back Button Handling:** Implemented a 'popstate' event listener, enabling the modal to close when the back button is pressed on mobile devices.

---

Closes #59