### PR TITLE
Refactor ThemeSettingsContext to use `useLocalStorage` hook

### DIFF
--- a/src/Contexts/ThemeSettingsContext.tsx
+++ b/src/Contexts/ThemeSettingsContext.tsx
@@ -1,4 +1,5 @@
-﻿import {createContext, useContext, useState, ReactNode, useEffect} from "react";
+﻿import {createContext, useContext, ReactNode} from "react";
+import {useLocalStorage} from "../Hooks/useLocalStorage.ts";
 
 type Mode = "dynamic" | "manual";
 type Weather = "clear" | "cloudy" | "stormy";
@@ -23,152 +24,12 @@ export const ThemeSettingsContext = createContext<ThemeSettingsContextType | nul
 
 export const ThemeSettingsProvider = ({children}: {children: ReactNode}) => {
 
-    //region timeMode
+    const [timeMode, setTimeMode] = useLocalStorage<Mode>("timeMode", "dynamic");
+    const [manualTime, setManualTime] = useLocalStorage<Time>("manualTime", 12);
+    const [weatherMode, setWeatherMode] = useLocalStorage<Mode>("weatherMode", "dynamic");
+    const [manualWeather, setManualWeather] = useLocalStorage<Weather>("manualWeather", "clear");
+    const [debugMode, setDebugMode] = useLocalStorage<Debug>("debugMode", false);
 
-    const initializeTimeMode = (): Mode => {
-        try {
-            const savedTimeMode = localStorage.getItem("timeMode");
-
-            if (savedTimeMode === "dynamic" || savedTimeMode === "manual") {
-                return savedTimeMode;
-            }
-        }
-        catch (e) {
-            console.error("Error reading timeMode from localstorage:", e);
-        }
-        return "dynamic";
-    }
-
-    const [timeMode, setTimeMode] = useState<Mode>(initializeTimeMode);
-
-    useEffect(() => {
-        try {
-            localStorage.setItem("timeMode", timeMode);
-        }
-        catch (e) {
-            console.error("Error writing timeMode to localstorage:", e);
-        }
-    }, [timeMode]);
-
-    //endregion
-
-    //region manualTime
-
-    const initializeManualTime = (): Time => {
-        try {
-            const savedManualTime = localStorage.getItem("manualTime");
-
-            if (savedManualTime !== null) {
-                return parseInt(savedManualTime);
-            }
-        }
-        catch (e) {
-            console.error("Error reading manualTime from localstorage:", e);
-        }
-        return 12;
-    }
-
-    const [manualTime, setManualTime] = useState<Time>(initializeManualTime);
-
-    useEffect(() => {
-        try {
-            localStorage.setItem("manualTime", manualTime.toString());
-        }
-        catch (e) {
-            console.error("Error writing manualTime to localstorage:", e);
-        }
-    }, [manualTime]);
-
-    //endregion
-
-    //region weatherMode
-
-    const initializeWeatherMode = (): Mode => {
-        try {
-            const savedWeatherMode = localStorage.getItem("weatherMode");
-
-            if (savedWeatherMode === "dynamic" || savedWeatherMode === "manual") {
-                return savedWeatherMode;
-            }
-        }
-        catch (e) {
-            console.error("Error reading weatherMode from localstorage:", e);
-        }
-        return "dynamic";
-    }
-
-    const [weatherMode, setWeatherMode] = useState<Mode>(initializeWeatherMode);
-
-    useEffect(() => {
-        try {
-            localStorage.setItem("weatherMode", weatherMode);
-        }
-        catch (e) {
-            console.error("Error writing weatherMode to localstorage:", e);
-        }
-    }, [weatherMode]);
-
-    //endregion
-
-    //region ManualWeather
-
-    const initializeManualWeather = (): Weather => {
-        try {
-            const savedManualWeather = localStorage.getItem("manualWeather");
-
-            if (savedManualWeather === 'clear' || savedManualWeather === 'cloudy' || savedManualWeather === 'stormy') {
-                return savedManualWeather as Weather;
-            }
-        }
-        catch (e) {
-            console.error("Error reading manualWeather from localstorage:", e);
-        }
-        return "clear";
-    }
-
-    const [manualWeather, setManualWeather] = useState<Weather>(initializeManualWeather);
-
-    useEffect(() => {
-        try {
-            localStorage.setItem("manualWeather", manualWeather);
-        }
-        catch (e) {
-            console.error("Error writing manualWeather to localstorage:", e);
-        }
-    }, [manualWeather]);
-
-    //endregion
-
-    //region debugMode
-
-    const initializeDebugMode = (): Debug => {
-        try {
-            const savedDebugMode = localStorage.getItem("debugMode");
-
-            if (savedDebugMode === "true") {
-                return true;
-            } else {
-                return false;
-            }
-        }
-        catch (e) {
-            console.error("Error reading debugMode from localstorage:", e);
-        }
-        return false;
-    }
-
-    const [debugMode, setDebugMode] = useState<Debug>(initializeDebugMode);
-
-    useEffect(() => {
-        try {
-            localStorage.setItem("debugMode", debugMode.toString());
-        }
-        catch (e) {
-            console.error("Error writing debugMode to localstorage:", e);
-        }
-    }, [debugMode]);
-
-    //endregion
 
     const value = {
         timeMode,

--- a/src/Hooks/useLocalStorage.ts
+++ b/src/Hooks/useLocalStorage.ts
@@ -1,0 +1,32 @@
+﻿import {useEffect, useState} from "react";
+
+
+function getStoredValue<T>(key:string, initialValue:T):T{
+    if (typeof window === 'undefined') {
+        return initialValue;
+    }
+
+    try {
+        const item = localStorage.getItem(key);
+        return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+        console.error(error);
+        return initialValue;
+    }
+}
+
+export const useLocalStorage = <T>(key:string, initialValue:T) => {
+    const [storedValue, setStoredValue] = useState<T>(()=>{
+        return getStoredValue(key, initialValue);
+    })
+
+    useEffect(() => {
+        try {
+            window.localStorage.setItem(key, JSON.stringify(storedValue));
+        } catch (error) {
+            console.error(error);
+        }
+    }, [key, storedValue]);
+
+    return [storedValue, setStoredValue] as const;
+}


### PR DESCRIPTION
Simplified the `ThemeSettingsContext` by implementing a reusable `useLocalStorage` hook:  
- Replaced redundant `useState` and `useEffect` logic.  
- Centralized state persistence and error handling logic.  
- Improved code maintainability and reduced duplication.  

---

Closes #19